### PR TITLE
Add debian-archive-keyring for apt update

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -31,17 +31,15 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     apt-get update -y && \
     apt-get install --no-install-recommends -y -q python unzip ca-certificates build-essential \
     libatlas-base-dev liblapack-dev gfortran libpng-dev libfreetype6-dev libxft-dev libxml2-dev \
-    python-dev python-setuptools python-zmq openssh-client wget curl git pkg-config zip && \
+    python-dev python-setuptools python-zmq openssh-client wget curl git pkg-config zip \
+    debian-archive-keyring && \
     easy_install pip && \
     mkdir -p /tools && \
 
 # Save GPL source packages
     mkdir -p /srcs && \
     cd /srcs && \
-    # We have to use allow-unauthenticated since Ubuntu can't verify the keys for the source
-    # repos.  We don't care since we only download these sources for licensing reasons and
-    # don't actually use them.
-    apt-get source --allow-unauthenticated -d wget git python-zmq ca-certificates pkg-config libpng-dev && \
+    apt-get source -d wget git python-zmq ca-certificates pkg-config libpng-dev && \
     wget --progress=dot:mega https://mirrors.kernel.org/gnu/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2 && \
     cd / && \
 


### PR DESCRIPTION
Without this package `apt update` inside the datalab VM issues GPG key verification warnings.